### PR TITLE
Renderer fixes

### DIFF
--- a/ChonkyStation3/ChonkyStation3.cpp
+++ b/ChonkyStation3/ChonkyStation3.cpp
@@ -1,9 +1,19 @@
-﻿#include <iostream>
+#include <iostream>
 #include <string>
 #include <format>
 #include <SDL.h>
 #include "PlayStation3.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+
+// Gently ask to use the discrete Nvidia/AMD GPU if possible instead of
+// integrated graphics
+extern "C" {
+__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+__declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
 
 static constexpr double MS_PER_FRAME = 1000.0 / 60.0;
 

--- a/ChonkyStation3/ChonkyStation3.cpp
+++ b/ChonkyStation3/ChonkyStation3.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv) {
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 5);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
     
     fs::path file = argv[1];
     std::string title = std::format("ChonkyStation3 | {}", file.filename().string());

--- a/ChonkyStation3/RSX/FragmentShaderDecompiler.cpp
+++ b/ChonkyStation3/RSX/FragmentShaderDecompiler.cpp
@@ -64,11 +64,11 @@ vec4 unimpl;
             break;
         }
         case RSXFragment::EX2: {
-            main += std::format("{}{} = {}(exp2({}));\n", dest(instr), mask_str, type, source(instr, 0));
+            main += std::format("{}{} = {}(vec4(exp2({}.x)));\n", dest(instr), mask_str, type, source(instr, 0));
             break;
         }
         case RSXFragment::LG2: {
-            main += std::format("{}{} = {}(log2({}));\n", dest(instr), mask_str, type, source(instr, 0));
+            main += std::format("{}{} = {}(vec4(log2({}.x)));\n", dest(instr), mask_str, type, source(instr, 0));
             break;
         }
         case RSXFragment::NRM: {


### PR DESCRIPTION
Fix EXP2/LOG2 implementations, use discrete GPU and actually create a MacOS-compatible GL context