### PR TITLE
Add top-level Filesystem folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.userosscache
 *.sln.docstates
 
+Filesystem/
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 


### PR DESCRIPTION
When running ChonkyStation 3 from outside the build folder (Doing `./build/Chonkystation3`), it creates the Filesystem folder in the root of the repo and Github Desktop pesters me into committing it