### PR TITLE
[PPU] Fix mtcrf

### DIFF
--- a/ChonkyStation3/PPU/Backends/PPUInterpreter.cpp
+++ b/ChonkyStation3/PPU/Backends/PPUInterpreter.cpp
@@ -1615,16 +1615,14 @@ void PPUInterpreter::mtcrf(const Instruction& instr) {
                 count++;
             }
         }
-        Helpers::debugAssert(count == 1, "mtocrf with count != 1\n");
 
-        state.cr.setCRField(n, (state.gprs[instr.rs] >> (4 * n)) & 0xf);
-        //state.cr.setCRField(n, (state.gprs[instr.rs] >> (28 - (4 * n))) & 0xf);
+        Helpers::debugAssert(count == 1, "mtocrf with count != 1\n");
+        state.cr.setCRField(7 - n, (state.gprs[instr.rs] >> (4 * n)) & 0xf);
     }
     else {  // mtcrf
         for (int i = 0; i < 8; i++) {
             if ((instr.fxm >> i) & 1) {
-                state.cr.setCRField(i, (state.gprs[instr.rs] >> (4 * i)) & 0xf);
-                //state.cr.setCRField(i, (state.gprs[instr.rs] >> (28 - (4 * i))) & 0xf);
+                state.cr.setCRField(7 - i, (state.gprs[instr.rs] >> (4 * i)) & 0xf);
             }
         }
     }


### PR DESCRIPTION
Fixes nullptr crashes in Minecraft, COD Classic, Hotline Miami, TLOU manual, Tomb Raider, Oblivion, and more, allowing them to go further.

Makes Undertale boot, with broken graphics
![image](https://github.com/user-attachments/assets/95f98560-cee4-4b2e-9d69-d67b66869c3b)
![image](https://github.com/user-attachments/assets/b9726127-b007-46ad-b91c-44ef37dcfa1f)
